### PR TITLE
fix(network): the process exiting without exit code

### DIFF
--- a/src/network/request.ts
+++ b/src/network/request.ts
@@ -43,9 +43,6 @@ export class ServerlessRequest extends IncomingMessage {
     this.url = url;
     this.ip = remoteAddress;
 
-    // ref: https://github.com/nodejs/node/blob/master/lib/internal/streams/readable.js#L1278
-    (this as any)._readableState.endEmitted = true;
-
     this._read = () => {
       this.push(body);
       this.push(null);

--- a/test/core/base-handler.spec.ts
+++ b/test/core/base-handler.spec.ts
@@ -127,7 +127,6 @@ describe(BaseHandler.name, () => {
       adapterRequest.remoteAddress,
     );
 
-    expect(request.readableEnded).toBe(true);
     expect(response).toBeInstanceOf(ServerlessResponse);
   });
 });

--- a/test/network/request.spec.ts
+++ b/test/network/request.spec.ts
@@ -23,7 +23,6 @@ describe('ServerlessRequest', () => {
     expect(request).toHaveProperty('ip', remoteAddress);
     expect(request).toHaveProperty('body', body);
     expect(request).toHaveProperty('complete', true);
-    expect(request.readableEnded).toBe(true);
     expect(request).toHaveProperty('httpVersion', '1.1');
     expect(request).toHaveProperty('httpVersionMajor', 1);
     expect(request).toHaveProperty('httpVersionMinor', 1);
@@ -32,7 +31,6 @@ describe('ServerlessRequest', () => {
     expect(request.socket).toHaveProperty('remoteAddress', remoteAddress);
     expect(request.socket).toHaveProperty('end', NO_OP);
     expect(request.socket).toHaveProperty('destroy', NO_OP);
-    expect((request as any)._readableState).toHaveProperty('endEmitted', true);
     expect(request.socket.address()).toHaveProperty('port', 443);
   });
 


### PR DESCRIPTION
When I integrate with NestJS, I could create GET requests but POST requests returned null in
response because the NodeJS exits when it could not wait an promise. This bug was caused by
request.ts when I override the internal variable of stream _readableState, with this, the NestJS
could not process the request and the process exits after some seconds without exit code.

Refs: 

- https://github.com/MatrixAI/js-polykey/issues/307

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

I just remove the overrides in internal state of the stream.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
