### PR TITLE
fix(serverless-adapter): passing wrong constant to binary settings

### DIFF
--- a/src/serverless-adapter.ts
+++ b/src/serverless-adapter.ts
@@ -8,7 +8,12 @@ import {
   ResolverContract,
   ServerlessHandler,
 } from './contracts';
-import { DEFAULT_BINARY_ENCODINGS, ILogger, createDefaultLogger } from './core';
+import {
+  DEFAULT_BINARY_CONTENT_TYPES,
+  DEFAULT_BINARY_ENCODINGS,
+  ILogger,
+  createDefaultLogger,
+} from './core';
 
 //#endregion
 
@@ -61,11 +66,11 @@ export class ServerlessAdapter<
   /**
    * Settings for whether the response should be treated as binary or not
    *
-   * @default `contentEncodings` and `contentTypes` are set with {@link DEFAULT_BINARY_ENCODINGS} and {@link DEFAULT_BINARY_ENCODINGS}, respectively.
+   * @default `contentEncodings` and `contentTypes` are set with {@link DEFAULT_BINARY_ENCODINGS} and {@link DEFAULT_BINARY_CONTENT_TYPES}, respectively.
    */
   protected binarySettings: BinarySettings = {
     contentEncodings: DEFAULT_BINARY_ENCODINGS,
-    contentTypes: DEFAULT_BINARY_ENCODINGS,
+    contentTypes: DEFAULT_BINARY_CONTENT_TYPES,
   };
 
   /**


### PR DESCRIPTION
fix #12

### Description of change

Fix the default constant and added tests to ensure the default values are correct inside serverless-adapter.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
