### PR TITLE
feat(response): added support for next.js ssr response data in Uint8Array

### DIFF
--- a/src/network/request.ts
+++ b/src/network/request.ts
@@ -31,7 +31,7 @@ export interface ServerlessRequestProps {
   /**
    * The body from the event source
    */
-  body?: Buffer;
+  body?: Buffer | Uint8Array;
 
   /**
    * The IP Address from caller
@@ -81,5 +81,5 @@ export class ServerlessRequest extends IncomingMessage {
   }
 
   ip?: string;
-  body?: Buffer;
+  body?: Buffer | Uint8Array;
 }

--- a/src/network/response.ts
+++ b/src/network/response.ts
@@ -11,11 +11,16 @@ const HEADERS = Symbol('Response headers');
 function getString(data: Buffer | string | unknown) {
   if (Buffer.isBuffer(data)) return data.toString('utf8');
   else if (typeof data === 'string') return data;
+  else if (data instanceof Uint8Array) return new TextDecoder().decode(data);
   else throw new Error(`response.write() of unexpected type: ${typeof data}`);
 }
 
 function addData(stream: ServerlessResponse, data: Uint8Array | string) {
-  if (Buffer.isBuffer(data) || typeof data === 'string')
+  if (
+    Buffer.isBuffer(data) ||
+    typeof data === 'string' ||
+    data instanceof Uint8Array
+  )
     stream[BODY].push(Buffer.from(data));
   else throw new Error(`response.write() of unexpected type: ${typeof data}`);
 }

--- a/test/network/response.spec.ts
+++ b/test/network/response.spec.ts
@@ -59,6 +59,13 @@ describe('ServerlessResponse', () => {
       body: '{"test": true}' as any,
     });
 
+    const requestWithUintArray = new ServerlessRequest({
+      ...defaultParams,
+      body: Uint8Array.from(
+        Array.from('{"test": true}').map(c => c.charCodeAt(0)),
+      ),
+    });
+
     const requestHead = new ServerlessRequest({
       ...defaultParams,
       method: 'HEAD',
@@ -72,6 +79,7 @@ describe('ServerlessResponse', () => {
       [request, 0, true],
       [requestWithBody, requestWithBody.body!.length, true],
       [requestWithBodyString, requestWithBodyString.body!.length, true],
+      [requestWithUintArray, requestWithUintArray.body!.length, true],
       [requestHead, 0, false],
     ];
 
@@ -107,9 +115,16 @@ describe('ServerlessResponse', () => {
   });
 
   it('should can pipe response and return correct data', async () => {
-    const options: [value: string | Buffer, expectedValue: string][] = [
+    const options: [
+      value: string | Buffer | Uint8Array,
+      expectedValue: string,
+    ][] = [
       ['test', 'test'],
       [Buffer.from('{"yo": true}', 'utf-8'), '{"yo": true}'],
+      [
+        Uint8Array.from(Array.from('{"test": true}').map(c => c.charCodeAt(0))),
+        '{"test": true}',
+      ],
     ];
 
     for (const [testedData, expectedValue] of options) {
@@ -163,7 +178,11 @@ describe('ServerlessResponse', () => {
   });
 
   it('should call correctly the callback with valid data in response', () => {
-    const options = ['test', Buffer.from('testB', 'utf-8')];
+    const options = [
+      'test',
+      Buffer.from('testB', 'utf-8'),
+      Uint8Array.from(Array.from('{"test": true}').map(c => c.charCodeAt(0))),
+    ];
 
     for (const testedData of options) {
       const response = new ServerlessResponse({


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Inspired by https://github.com/vendia/serverless-express/issues/539,
added support for Uint8Array which is used by Next.js.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Added documentation inside `www/docs/main` folder.
- [x] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
