### PR TITLE
docs: fix typo "CustomContext" -> "TrpcContext"

### DIFF
--- a/www/docs/main/frameworks/trpc.mdx
+++ b/www/docs/main/frameworks/trpc.mdx
@@ -51,7 +51,7 @@ const frameworkOptions: TrpcFrameworkOptions<CustomContext> = {
   createContext: () => ({ currentDate: new Date() }),
 };
 
-const framework = new TrpcFramework<CustomContext>(frameworkOptions);
+const framework = new TrpcFramework<TrpcContext>(frameworkOptions);
 
 export const handler = ServerlessAdapter.new(appRouter)
   .setFramework(framework)


### PR DESCRIPTION
### Description of change

Fix typo in docs. As far as I can tell it should be `TrpcContext` instead of `CustomContext` in this instance.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch (N/A)
- [ ] `npm run lint` passes with this change (N/A)
- [ ] `npm run test` passes with this changev
- [ ] This pull request links relevant issues as `Fixes #0000` (N/A)
- [ ] There are new or updated unit tests validating the change (N/A)
- [ ] Added documentation inside `www/docs/main` folder. (N/A)
- [ ] Included new files inside `index.doc.ts`. (N/A)
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

