### PR TITLE
refactor(trpc): deprecate BufferToJSObjectTransformer to promote body-parser

### DIFF
--- a/src/frameworks/trpc/trpc.framework.ts
+++ b/src/frameworks/trpc/trpc.framework.ts
@@ -17,6 +17,7 @@ import { getDefaultIfUndefined, getFlattenedHeadersMap } from '../../core';
 /**
  * The transformer that is responsible to transform buffer's input to javascript objects
  *
+ * @deprecated You should use {@link JsonBodyParserFramework} instead, is more reliable and enable you to use transformer of trpc to other things.
  * @breadcrumb Frameworks / TrpcFramework
  * @public
  */

--- a/www/docs/main/frameworks/trpc.mdx
+++ b/www/docs/main/frameworks/trpc.mdx
@@ -12,15 +12,18 @@ The following examples only work with tRPC over HTTP, you cannot use this framew
 First, you need to ensure you have the libs installed, so run this code:
 
 ```bash
-npm i --save @trpc/server
+npm i --save @trpc/server body-parser
 ```
+
+> `body-parser` is needed to parse the body of the request to JSON.
 
 Then, you just need to use the [TrpcFramework](../../api/Frameworks/TrpcFramework) when you create your adapter, like:
 
 ```ts title="index.ts"
 import * as trpc from '@trpc/server';
 import { ServerlessAdapter } from '@h4ad/serverless-adapter';
-import { TrpcFramework, TrpcAdapterContext, TrpcFrameworkOptions, BufferToJSObjectTransformer } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
+import { TrpcFramework, TrpcAdapterContext, TrpcFrameworkOptions } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
+import { JsonBodyParserFramework } from '@h4ad/serverless-adapter/lib/frameworks/body-parser';
 import { CorsFramework } from '@h4ad/serverless-adapter/lib/frameworks/cors';
 import { z } from 'zod';
 
@@ -29,7 +32,6 @@ type TrpcContext = TrpcAdapterContext<CustomContext>;
 
 const appRouter = trpc
   .router<TrpcContext>()
-  .transformer(new BufferToJSObjectTransformer())
   .query('getUser', {
     input: z.string(),
     async resolve(req) {
@@ -53,7 +55,8 @@ const frameworkOptions: TrpcFrameworkOptions<CustomContext> = {
 };
 
 const framework = new TrpcFramework<TrpcContext>(frameworkOptions);
-const corsFramework = new CorsFramework(framework); // see more about: https://serverless-adapter.viniciusl.com.br/docs/main/frameworks/cors
+const jsonFramework = new JsonBodyParserFramework(framework);
+const corsFramework = new CorsFramework(jsonFramework); // see more about: https://serverless-adapter.viniciusl.com.br/docs/main/frameworks/cors
 
 export const handler = ServerlessAdapter.new(appRouter)
   .setFramework(corsFramework)
@@ -66,13 +69,6 @@ export const handler = ServerlessAdapter.new(appRouter)
   // after put all methods necessary, just call the build method.
   .build();
 ```
-
-:::warning
-
-Always add the [BufferToJSObjectTransformer](../../api/Frameworks/TrpcFramework/BufferToJSObjectTransformer) because the input can be a buffer
-when you sent some JSON inside `body` on mutation, so this transformer will be responsible to convert back to JS Object.
-
-:::
 
 :::tip
 
@@ -92,14 +88,13 @@ With this behavior, to integrate with [SQSAdapter](/docs/main/adapters/aws/sqs),
 ```typescript title="index.ts"
 import type { SQSEvent } from 'aws-lambda';
 import * as trpc from '@trpc/server';
-import { TrpcAdapterContext, BufferToJSObjectTransformer } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
+import { TrpcAdapterContext } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
 import { z } from 'zod';
 
 type TrpcContext = TrpcAdapterContext<unknown>;
 
 const appRouter = trpc
   .router<TrpcContext>()
-  .transformer(new BufferToJSObjectTransformer())
   .mutation('sqs', {
     input: z.object({
       Records: z.array(z.any()),
@@ -142,14 +137,15 @@ like the code below:
 ```typescript title="index.ts"
 import * as trpc from '@trpc/server';
 import { ServerlessAdapter } from '@h4ad/serverless-adapter';
-import { TrpcFramework, TrpcAdapterContext, BufferToJSObjectTransformer, TrpcFrameworkOptions } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
+import { TrpcFramework, TrpcAdapterContext, TrpcFrameworkOptions } from '@h4ad/serverless-adapter/lib/frameworks/trpc';
+import { JsonBodyParserFramework } from '@h4ad/serverless-adapter/lib/frameworks/body-parser';
+import { CorsFramework } from '@h4ad/serverless-adapter/lib/frameworks/cors';
 
 type CustomContext = { potato: boolean };
 type TrpcContext = TrpcAdapterContext<CustomContext>;
 
 const appRouter = trpc
   .router<TrpcContext>()
-  .transformer(new BufferToJSObjectTransformer())
   .mutation('add', {
     async resolve({ ctx }) {
       // get the request url
@@ -167,7 +163,8 @@ const frameworkOptions: TrpcFrameworkOptions<TrpcContext> = {
 };
 
 const framework = new TrpcFramework<TrpcContext>(frameworkOptions);
-const corsFramework = new CorsFramework(framework); // see more about: https://serverless-adapter.viniciusl.com.br/docs/main/frameworks/cors
+const jsonFramework = new JsonBodyParserFramework(framework);
+const corsFramework = new CorsFramework(jsonFramework); // see more about: https://serverless-adapter.viniciusl.com.br/docs/main/frameworks/cors
 
 export const handler = ServerlessAdapter.new(appRouter)
   .setFramework(corsFramework)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Instead of using `BufferToJSObjectTransformer` and consume the transformer of trpc, now you can use `JsonBodyParserFramework` instead to parse the content that comes as buffer.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Added documentation inside `www/docs/main` folder.
- [x] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
