### PR TITLE
fix HTTP 301/302 not work with AwsStreamHandler

### DIFF
--- a/src/handlers/aws/aws-stream.handler.ts
+++ b/src/handlers/aws/aws-stream.handler.ts
@@ -301,7 +301,7 @@ export class AwsStreamHandler<TApp> extends BaseHandler<
         // so I have this thing just to fix this issue
         // ref: https://stackoverflow.com/a/37303151
         const isHundreadStatus = status >= 100 && status < 200;
-        const isNoContentStatus = status === 304 || status === 204;
+        const isNoContentStatus = status >= 300 && status < 400;
         const isHeadRequest = requestValues.method === 'HEAD';
 
         if (isHundreadStatus || isNoContentStatus || isHeadRequest) {


### PR DESCRIPTION
### Description of change

[300 Multiple Choices](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/300)
[301 Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301)
[302 Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302)
[303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303)
[304 Not Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304)
[307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307)
[308 Permanent Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308)

I believe these HTTP code should have no body as well.

Or at least make 301/302 in the list, otherwise we cannot send 301/302 redirect with AwsStreamHandler.