### PR TITLE
fix(response-stream): fix response with no content doesn't correctly end the writable stream

### DIFF
--- a/src/handlers/aws/aws-stream.handler.ts
+++ b/src/handlers/aws/aws-stream.handler.ts
@@ -296,19 +296,9 @@ export class AwsStreamHandler<TApp> extends BaseHandler<
           awsMetadata,
         );
 
-        // some status do not return body, and
-        // for some unknown reason, we cannot finish the stream without writing at least once
-        // so I have this thing just to fix this issue
-        // ref: https://stackoverflow.com/a/37303151
-        const isHundreadStatus = status >= 100 && status < 200;
-        const isNoContentStatus = status === 304 || status === 204;
-        const isHeadRequest = requestValues.method === 'HEAD';
-
-        if (isHundreadStatus || isNoContentStatus || isHeadRequest) {
-          finalResponse.write('');
-          // end the response to avoid waiting for nothing
-          response.end();
-        }
+        // We must call write with an empty string to trigger the awsMetadata to be sent
+        // https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/2ce88619fd176a5823bc5f38c5484d1cbdf95717/src/HttpResponseStream.js#L22
+        finalResponse.write('');
 
         return finalResponse;
       },


### PR DESCRIPTION
### Description of change

Previously we are detecting HTTP status codes that indicate no body (`status >= 100 && status < 200 || status === 304 || status === 204 || method === 'HEAD'`). This is not great since every HTTP status code can have empty body. It's totally legit to have a response with 200 status code but empty body.

Actually, the root cause of stream not being correctly ended, is that we skipped the `0\r\n\r\n` right after the HTTP header:

![image](https://github.com/H4ad/serverless-adapter/assets/5107241/02c157bb-f547-4202-8e81-ba7b843a018a)

As you can see in the screenshot (captured from AWS Lambda logs), for responses with empty body, the first write contains both headers and the chunk terminator `0\r\n\r\n`.

This PR tries to detect that chunk terminator immediately after the headers, so we can close the stream correctly.

Tested working on AWS lambda with examples from https://github.com/H4ad/serverless-adapter-examples (`fastify-aws-stream` and `nestjs-aws-stream`).


### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Added documentation inside `www/docs/main` folder.
- [ ] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
