### PR TITLE
docs: fix Apollo Server package name in npm command

### DIFF
--- a/www/docs/main/frameworks/apollo-server.mdx
+++ b/www/docs/main/frameworks/apollo-server.mdx
@@ -12,7 +12,7 @@ In the following section, you will see how to integrate any cloud with your Apol
 First, you need to ensure you have the libs installed, so run this code:
 
 ```bash
-npm i --save apollo-server
+npm i --save @apollo/server
 ```
 
 Also, to be able to handle JSON requests, we can use [JsonBodyParserFramework](./helpers/body-parser), so let's install it:


### PR DESCRIPTION
This makes it match the code samples below by using the AS4 package name.
