### PR TITLE
fix(apig-v1-adapter): lowercase headers

### DIFF
--- a/src/adapters/aws/api-gateway-v1.adapter.ts
+++ b/src/adapters/aws/api-gateway-v1.adapter.ts
@@ -8,6 +8,7 @@ import type {
   GetResponseAdapterProps,
   OnErrorProps,
 } from '../../contracts';
+import { keysToLowercase } from '../../core';
 import {
   type StripBasePathFn,
   buildStripBasePath,
@@ -42,6 +43,13 @@ export interface ApiGatewayV1Options {
    * @defaultValue true
    */
   throwOnChunkedTransferEncoding?: boolean;
+
+  /**
+   * Emulates the behavior of Node.js `http` module by ensuring all request headers are lowercase.
+   *
+   * @defaultValue false
+   */
+  lowercaseRequestHeaders?: boolean;
 }
 
 /**
@@ -122,7 +130,9 @@ export class ApiGatewayV1Adapter
    */
   public getRequest(event: APIGatewayProxyEvent): AdapterRequest {
     const method = event.httpMethod;
-    const headers = { ...event.headers };
+    const headers = this.options?.lowercaseRequestHeaders
+      ? keysToLowercase(event.headers)
+      : { ...event.headers };
 
     for (const multiValueHeaderKey of Object.keys(
       event.multiValueHeaders || {},

--- a/src/core/headers.ts
+++ b/src/core/headers.ts
@@ -151,3 +151,12 @@ export function parseHeaders(
 
   return result;
 }
+
+export function keysToLowercase<T extends Record<string, unknown>>(
+  obj: T,
+): { [K in keyof T as Lowercase<string & K>]: T[K] } {
+  const result: any = {};
+  for (const [k, v] of Object.entries(obj)) result[k.toLowerCase()] = v;
+
+  return result as { [K in keyof T as Lowercase<string & K>]: T[K] };
+}

--- a/test/adapters/aws/api-gateway-v1.adapter.spec.ts
+++ b/test/adapters/aws/api-gateway-v1.adapter.spec.ts
@@ -75,6 +75,22 @@ describe(ApiGatewayV1Adapter.name, () => {
       expect(result).toHaveProperty('path', resultPath);
     });
 
+    it('should return lowercase request headers if option `lowercaseRequestHeaders` is `true`', () => {
+      const method = 'GET';
+      const path = '/events';
+
+      adapter = new ApiGatewayV1Adapter({ lowercaseRequestHeaders: true });
+      const event = createApiGatewayV1(method, path);
+      event.headers['Cookie'] = 'test=test;';
+
+      const { headers } = adapter.getRequest(event);
+
+      expect(headers).not.toHaveProperty('Cookie');
+      expect(headers).toHaveProperty('cookie');
+      expect(headers).not.toHaveProperty('Accept');
+      expect(headers).toHaveProperty('accept');
+    });
+
     it('should return the correct mapping for the request when it has no body', () => {
       const method = 'GET';
       const path = '/users';

--- a/www/docs/main/adapters/aws/api-gateway-v1.mdx
+++ b/www/docs/main/adapters/aws/api-gateway-v1.mdx
@@ -119,6 +119,15 @@ When you configure your API with some `basePath` like `/prod`, you should either
 
 :::
 
+You can also ensure request headers are lowercase like the default behavior of Node.js `http` module by setting the `lowercaseRequestHeaders` option to `true`.
+
+:::caution
+
+ApiGateway may already be ensuring your headers are lowercase but it may be worth confirming in your own system as many libraries in the Node.js ecosystem will assume this lowercasing.
+
+:::
+
+
 ## Usage
 
 To add support to AWS API Gateway V1 you do the following:


### PR DESCRIPTION
### Description of change

Adding back the default behavior of emulating Node.js `http` by lowercasing all request headers. Large parts of JS ecosystem assume that these headers, particularly `cookie` header, can be accessed with the lowercase key.

This behavior was present in past versions of the `ApiGatewayV1Adapter` so please correct me if there is good reason that this was changed, but from my perspective it appears it may have just been missed. This past PR is an example, https://github.com/H4ad/serverless-adapter/pull/25.

Also, potentially related to #73 

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Added documentation inside `www/docs/main` folder.
- [ ] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
