### PR TITLE
Update throwOnChunkedTransferEncoding parameter in API Gateway adapter docs

### DIFF
--- a/www/docs/main/adapters/aws/api-gateway-v1.mdx
+++ b/www/docs/main/adapters/aws/api-gateway-v1.mdx
@@ -152,10 +152,10 @@ export const handler = ServerlessAdapter.new(app)
 
 API Gateway V1 currently didn't support chunked transfer, so we throw an exception when you send the `transfer-encoding=chunked`.
 
-But, you can disable the exception by setting the `throwOnChunkedTransfer` to `false` in the [ApiGatewayV1Options](/docs/api/Adapters/AWS/ApiGatewayV1Adapter/ApiGatewayV1Options).
+But, you can disable the exception by setting the `throwOnChunkedTransferEncoding` to `false` in the [ApiGatewayV1Options](/docs/api/Adapters/AWS/ApiGatewayV1Adapter/ApiGatewayV1Options).
 
 ```ts title="index.ts"
-new ApiGatewayV1Adapter({ throwOnChunkedTransfer: false })
+new ApiGatewayV1Adapter({ throwOnChunkedTransferEncoding: false })
 ```
 
 The response body will be buffered without the special characters introduced by the chunked transfer keeping the body complete.

--- a/www/docs/main/adapters/aws/api-gateway-v2.mdx
+++ b/www/docs/main/adapters/aws/api-gateway-v2.mdx
@@ -133,10 +133,10 @@ export const handler = ServerlessAdapter.new(app)
 
 API Gateway V2 currently didn't support chunked transfer, so we throw an exception when you send the `transfer-encoding=chunked`.
 
-But, you can disable the exception by setting the `throwOnChunkedTransfer` to `false` in the [ApiGatewayV2Options](/docs/api/Adapters/AWS/ApiGatewayV2Adapter/ApiGatewayV2Options).
+But, you can disable the exception by setting the `throwOnChunkedTransferEncoding` to `false` in the [ApiGatewayV2Options](/docs/api/Adapters/AWS/ApiGatewayV2Adapter/ApiGatewayV2Options).
 
 ```ts title="index.ts"
-new ApiGatewayV1Adapter({ throwOnChunkedTransfer: false })
+new ApiGatewayV1Adapter({ throwOnChunkedTransferEncoding: false })
 ```
 
 The response body will be buffered without the special characters introduced by the chunked transfer keeping the body complete.


### PR DESCRIPTION
### Description of change

The docs for API Gateway list the option as `throwOnChunkedTransfer` when it should be `throwOnChunkedTransferEncoding`

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change~
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Added documentation inside `www/docs/main` folder.
- [ ] Included new files inside `index.doc.ts`.
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)