### PR TITLE
ci(release): enable trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,3 @@ jobs:
       - name: NPM Publish
         run: npm publish --provenance --access public
         if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
To avoid using tokens during publish.