### PR TITLE
fix(default-handler): support AWS Lambda Node.js 24 handler arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Bug Fixes
-
-* **default-handler:** fix `Runtime.CallbackHandlerDeprecated` on AWS Lambda Node.js 24 by reducing handler arity while preserving positional callback compatibility for older runtimes
-
 ## [4.4.0](https://github.com/H4ad/serverless-adapter/compare/v4.3.2...v4.4.0) (2024-12-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **default-handler:** fix `Runtime.CallbackHandlerDeprecated` on AWS Lambda Node.js 24 by reducing handler arity while preserving positional callback compatibility for older runtimes
+
 ## [4.4.0](https://github.com/H4ad/serverless-adapter/compare/v4.3.2...v4.4.0) (2024-12-01)
 
 

--- a/src/handlers/default/default.handler.ts
+++ b/src/handlers/default/default.handler.ts
@@ -54,7 +54,9 @@ export class DefaultHandler<
     respondWithErrors: boolean,
     log: ILogger,
   ): ServerlessHandler<TReturn> {
-    return (event: TEvent, context: TContext, callback?: TCallback) => {
+    return (event: TEvent, context: TContext, ...args: [TCallback?]) => {
+      const [callback] = args;
+
       this.onReceiveRequest(
         log,
         event,

--- a/test/handlers/default.handler.spec.ts
+++ b/test/handlers/default.handler.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src';
 import { ApiGatewayV2Adapter } from '../../src/adapters/aws';
 import { DefaultHandler } from '../../src/handlers/default';
+import { CallbackResolver } from '../../src/resolvers/callback';
 import { PromiseResolver } from '../../src/resolvers/promise';
 import { createApiGatewayV2 } from '../adapters/aws/utils/api-gateway-v2';
 import { FrameworkMock } from '../mocks/framework.mock';
@@ -157,5 +158,80 @@ describe('DefaultHandler', () => {
       'body',
       Buffer.from(JSON.stringify(response)).toString('base64'),
     );
+  });
+
+  describe('Node.js 24 handler arity', () => {
+    it('should expose handler arity compatible with NODEJS_24_X', () => {
+      const handler = defaultHandler.getHandler(
+        app,
+        new FrameworkMock(200, response),
+        adapters,
+        resolver,
+        binarySettings,
+        respondWithErrors,
+        logger,
+      );
+
+      expect(handler.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should resolve promise when called with two arguments only', async () => {
+      const framework = new FrameworkMock(200, response);
+
+      const handler = defaultHandler.getHandler(
+        app,
+        framework,
+        adapters,
+        resolver,
+        binarySettings,
+        respondWithErrors,
+        logger,
+      );
+
+      const event = createApiGatewayV2('GET', '/users', {}, { test: 'true' });
+      const context = { test: Symbol('unique') };
+
+      const result = await handler(event, context);
+
+      expect(result).toHaveProperty('statusCode', 200);
+      expect(result).toHaveProperty('body', JSON.stringify(response));
+    });
+  });
+
+  describe('CallbackResolver positional callback', () => {
+    it('should forward callback from third positional argument', async () => {
+      const callbackResolver = new CallbackResolver();
+      const framework = new FrameworkMock(200, response);
+      const mockCallback = vitest.fn();
+
+      const handler = defaultHandler.getHandler(
+        app,
+        framework,
+        adapters,
+        callbackResolver,
+        binarySettings,
+        respondWithErrors,
+        logger,
+      );
+
+      const event = createApiGatewayV2('GET', '/users', {}, { test: 'true' });
+      const context = { test: Symbol('unique') };
+
+      handler(event, context, mockCallback);
+
+      await new Promise<void>(resolve => {
+        setTimeout(() => {
+          expect(mockCallback).toHaveBeenCalledWith(
+            null,
+            expect.objectContaining({
+              statusCode: 200,
+              body: JSON.stringify(response),
+            }),
+          );
+
+          resolve();
+        }, 200);
+      });
+    });
   });
 });

--- a/test/serverless-adapter.spec.ts
+++ b/test/serverless-adapter.spec.ts
@@ -149,4 +149,15 @@ describe('ServerlessAdapter', () => {
         .build(),
     ).toThrow('one adapter');
   });
+
+  it('should build handler with arity compatible with NODEJS_24_X', () => {
+    const handler = ServerlessAdapter.new(null)
+      .setHandler(new DefaultHandler())
+      .setResolver(new PromiseResolver())
+      .setFramework(new FrameworkMock(200, {}))
+      .addAdapter(new ApiGatewayV2Adapter())
+      .build();
+
+    expect(handler.length).toBeLessThanOrEqual(2);
+  });
 });

--- a/www/docs/main/resolvers/callback.mdx
+++ b/www/docs/main/resolvers/callback.mdx
@@ -25,6 +25,12 @@ To use this resolver on AWS, you MUST leave [callbackWaitsForEmptyEventLoop](htt
 
 :::
 
+:::caution AWS Lambda Node.js 24
+
+Callback-based handlers are not supported on the AWS Lambda `nodejs24.x` runtime. Use [Promise Resolver](./promise) when deploying to Node.js 24 or later. `CallbackResolver` remains supported on Node.js 22 and earlier runtimes.
+
+:::
+
 # Usage
 
 To use, you can import and call the method [setResolver](../../api/ServerlessAdapter#method-setresolver), as per the code below:

--- a/www/docs/main/resolvers/promise.mdx
+++ b/www/docs/main/resolvers/promise.mdx
@@ -23,6 +23,12 @@ Only Huawei doesn't support Promise, or it was buggy in my time, so I suggest yo
 
 :::
 
+:::caution AWS Lambda Node.js 24
+
+`PromiseResolver` is **required** when deploying to AWS Lambda `nodejs24.x`. The Node.js 24 runtime no longer supports callback-based function handlers.
+
+:::
+
 # Usage
 
 To use, you can import and call the method [setResolver](../../api/ServerlessAdapter#method-setresolver), as per the code below:


### PR DESCRIPTION
### Description of change

[Fixes #378](https://github.com/H4ad/serverless-adapter/issues/378)

AWS Lambda `nodejs24.x` rejects handlers when `handler.length >= 3`, treating them as callback-style and failing at init with `Runtime.CallbackHandlerDeprecated`, even when using `PromiseResolver` and returning a `Promise`.

`DefaultHandler.getHandler()` previously returned a function with three formal parameters `(event, context, callback?)`, resulting in `handler.length === 3`.

**Current behavior:** deploy with `DefaultHandler` + `PromiseResolver` on `nodejs24.x` fails at init with `Runtime.CallbackHandlerDeprecated`.

**New behavior:** the handler is exported with `handler.length === 2` using rest parameters `(event, context, ...args)`, reading the callback from `args[0]` when passed positionally. This keeps `CallbackResolver` working on Node.js 22 and earlier while making `PromiseResolver` compatible with Node.js 24+ without a manual wrapper.

Similar approach: [honojs/hono#4782](https://github.com/honojs/hono/pull/4782).

**Verification:**
- Added regression tests for handler arity (`<= 2`), `PromiseResolver` with 2 args only, and `CallbackResolver` with positional callback
- `npm run lint` passes
- `npm run typecheck` passes
- Related tests (`default.handler`, `serverless-adapter`, `callback.resolver`, `azure`, `digital-ocean`) 23/23 pass
- `npm run build` fails locally on Windows due to command line length limit; expected to pass in CI (Linux)
- Reproduced originally on AWS Lambda `nodejs24.x` with NestJS + `LazyFramework` + `ExpressFramework` + `PromiseResolver` + `ApiGatewayV2Adapter`

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #378`
- [x] There are new or updated unit tests validating the change
- [x] Added documentation inside `www/docs/main` folder (`resolvers/callback.mdx`, `resolvers/promise.mdx`)
- [x] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)