### PR TITLE
ci(codecov): bump to v7

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm test
 
       - name: Get Coverage Info
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # https://github.com/codecov/codecov-action/commit/e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # https://github.com/codecov/codecov-action/releases/tag/v7.0.0
         with:
           fail_ci_if_error: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get Coverage Info
         if: ${{ steps.release.outputs.release_created }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # https://github.com/codecov/codecov-action/commit/e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # https://github.com/codecov/codecov-action/releases/tag/v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Codecov broke after https://github.com/codecov/codecov-action/releases/tag/v7.0.0

Ref: https://github.com/H4ad/serverless-adapter/actions/runs/28258691409/job/83729324584?pr=379