### PR TITLE
fix(response-stream): forward the write callback on empty body responses

### DIFF
--- a/src/network/response-stream.ts
+++ b/src/network/response-stream.ts
@@ -106,9 +106,18 @@ export class ServerlessStreamResponse extends ServerResponse {
 
           internalWritable = onReceiveHeaders(status, headers);
 
+          const dataAfterHeaders = stringData.substring(endHeaderIndex + 4);
+
           // If we get an endChunked right after header which means the response body is empty, we need to immediately end the writable
-          if (stringData.substring(endHeaderIndex + 4) === endChunked)
-            internalWritable.end();
+          // The callback must be forwarded, otherwise the response never emits `finish`
+          if (dataAfterHeaders === endChunked) {
+            internalWritable.end(cb);
+            return true;
+          }
+
+          // Responses without a body (eg. 204) write only the headers and never write again,
+          // so the callback has to be called here or the response never emits `finish`
+          if (dataAfterHeaders === '' && cb) process.nextTick(cb);
 
           return true;
         }

--- a/test/handlers/aws-stream.handler.spec.ts
+++ b/test/handlers/aws-stream.handler.spec.ts
@@ -300,6 +300,84 @@ describe('AwsStreamHandler', () => {
     });
   }
 
+  // when the response is sent after an await, the request is already being awaited by
+  // `waitForStreamComplete`, so the response has to actually emit `finish` to complete
+  for (const statusCode of [200, 204, 403, 500]) {
+    it(`should handle no content sent asynchronously with status ${statusCode}`, async () => {
+      const app = express();
+
+      app.get('/', async (_, res) => {
+        await new Promise(resolve => setImmediate(resolve));
+
+        res.status(statusCode).end();
+      });
+
+      const expressFramework = new ExpressFramework();
+
+      const handler = awsStreamHandler.getHandler(
+        app,
+        expressFramework,
+        adapters,
+        resolver,
+        binarySettings,
+        respondWithErrors,
+        logger,
+      );
+
+      const event = createApiGatewayV2('GET', '/', undefined);
+      const context = { test: Symbol('unique') };
+
+      const writable = new WritableMock();
+      const write = vitest.spyOn(writable, 'write');
+
+      await handler(event, writable, context);
+
+      expect(write).toHaveBeenCalledWith('');
+
+      const finalBuffer = Buffer.concat(writable.data);
+
+      expect(finalBuffer.toString()).toBe('');
+    }, 2000);
+  }
+
+  for (const statusCode of [200, 204, 403, 500]) {
+    it(`should handle an empty body sent asynchronously with status ${statusCode}`, async () => {
+      const app = express();
+
+      app.get('/', async (_, res) => {
+        await new Promise(resolve => setImmediate(resolve));
+
+        res.status(statusCode).send();
+      });
+
+      const expressFramework = new ExpressFramework();
+
+      const handler = awsStreamHandler.getHandler(
+        app,
+        expressFramework,
+        adapters,
+        resolver,
+        binarySettings,
+        respondWithErrors,
+        logger,
+      );
+
+      const event = createApiGatewayV2('GET', '/', undefined);
+      const context = { test: Symbol('unique') };
+
+      const writable = new WritableMock();
+      const write = vitest.spyOn(writable, 'write');
+
+      await handler(event, writable, context);
+
+      expect(write).toHaveBeenCalledWith('');
+
+      const finalBuffer = Buffer.concat(writable.data);
+
+      expect(finalBuffer.toString()).toBe('');
+    }, 2000);
+  }
+
   for (const statusCode of [200, 201, 202, 203, 204, 400, 401, 403, 404]) {
     it(`should handle writeHead with no content and status ${statusCode}`, async () => {
       const app = express();


### PR DESCRIPTION
The below report and the fixes were generated with Claude, but I am a human 🙂 and it fixes a real issue for me and my team . We are using Express, and in several places we were flagging errors to clients by calling `res.status(ERR_NUMBER).send()`, which sends an empty body, and empty bodies causes serverless-adapter to hang forever (or 180Kms, the timeout we set for our Lambda). This PR fixes both the no-body and empty-body cases so that the hang does not happen.

Thank you for all your work! This project has been very useful for us.

## Problem

When a framework handler sends an empty-body response **after an await**, the invocation
never completes. On `AwsStreamHandler` this means the Lambda idles until its timeout, even
though the client has already received the full response — status code, headers and all.

Reproduced with Express on `@h4ad/serverless-adapter@4.4.0`, and the same code is on `main`:

```ts
app.get("/", async (_, res) => {
  await something();
  res.status(500).send(); // or .send(''), or res.status(204).end()
});
```

`res.json({...})` and `res.send('body')` are fine. It is specifically responses with no body,
written after the event loop has turned.

## Root cause

`ServerlessStreamResponse`'s fake socket has two paths that end the internal writable, and only
one of them forwards the write callback.

When the response is written after an await, node has nothing corked and flushes the status line,
headers and chunked terminator in a **single** `socket.write(...)` — so the first-write
branch in `src/network/response-stream.ts` handles the whole response:

```ts
// If we get an endChunked right after header which means the response body is empty, we need to immediately end the writable
if (stringData.substring(endHeaderIndex + 4) === endChunked) internalWritable.end(); // <-- cb dropped
```

That `cb` is `OutgoingMessage.end()`'s `finish` callback. Dropping it means `onFinish` never runs,
the `ServerResponse` never emits `'finish'`, and so `waitForStreamComplete(response)` in
`AwsStreamHandler.forwardRequestToFramework` never resolves and `context.response.end()` is never
reached. The adjacent later-write branch already gets this right (`internalWritable.end(cb)`) —
which is why the multi-write cases work.

Responses with no body at all (eg. `res.status(204).end()`) fail for the mirror reason: `_hasBody`
is false, so node writes the headers and nothing else, and there is no later write left to run the
callback.

This traces to bded8cfe, which introduced the single-write branch to fix the writable not being
ended, but did not carry the callback through.

The existing `should handle no content with status …` tests don't catch it because they respond
**synchronously**: node sets `this.finished = true` at the end of `OutgoingMessage.end()`, so
`waitForStreamComplete`'s `isStreamEnded` short-circuit is already true by the time it is called
and the missing `'finish'` never matters. Move the same response behind an `await` and it hangs.

## Fix

In the first-write branch:

- when the chunked terminator arrives together with the headers, forward the callback —
  `internalWritable.end(cb)`, same as the later-write branch;
- when the headers are the entire write, run the callback on `process.nextTick`.

The second case deliberately does **not** end the writable, and is gated on there being nothing
after the header terminator, so a streaming response that flushes its headers first is unaffected
(`res.flushHeaders()` goes through `_send('')` with no callback, so there is nothing to run there).

## Tests

Added async counterparts of the existing "no content" cases to
`test/handlers/aws-stream.handler.spec.ts`, for both `res.status(n).end()` and
`res.status(n).send()` across statuses 200 / 204 / 403 / 500, with an explicit 2 s timeout so a
regression fails fast instead of waiting out the default.

- Without the fix: 8 failed (`Test timed out in 2000ms`), 37 passed.
- With the fix: 45 passed.
- Full suite: 57 files, 735 passed, 2 skipped. `tsc --noEmit`, `oxlint`, `oxfmt --check` and
  `tsup` build all clean.
